### PR TITLE
Add support for properties and environment variables

### DIFF
--- a/js/cli/src/run.ts
+++ b/js/cli/src/run.ts
@@ -8,6 +8,7 @@ export interface RunSimulationOptions extends RunJavaProcessOptions {
   resourcesFolder: string;
   resultsFolder: string;
   memory?: number;
+  runOptions: Record<string, string>;
 }
 
 export interface RunRecorderOptions extends RunJavaProcessOptions {
@@ -26,6 +27,7 @@ export const runSimulation = async (options: RunSimulationOptions): Promise<void
   const additionalClasspathElements = [options.resourcesFolder];
   const memoryArgs = options.memory !== undefined ? [`-Xms${options.memory}M`, `-Xmx${options.memory}M`] : [];
   const javaArgs = [
+    ...Object.entries(options.runOptions).map(([key, value]) => `-D${key}=${value}`),
     `-Dgatling.js.bundle.filePath=${options.bundleFile}`,
     `-Dgatling.js.simulation=${options.simulation}`,
     ...memoryArgs

--- a/js/core/src/index.ts
+++ b/js/core/src/index.ts
@@ -23,6 +23,7 @@ export * from "./filters";
 export { GlobalStore } from "./globalStore";
 export * from "./openInjection";
 export * from "./population";
+export { getOption, getEnvironmentVariable, GetWithDefault } from "./parameters";
 export * from "./protocol";
 export * from "./scenario";
 export * from "./session";

--- a/js/core/src/parameters.ts
+++ b/js/core/src/parameters.ts
@@ -1,0 +1,32 @@
+import { System as JvmSystem } from "@gatling.io/jvm-types";
+
+export interface GetWithDefault {
+  (name: string): string | undefined;
+  (name: string, defaultValue: string): string;
+}
+
+/**
+ * Gets the option indicated by the specified name.
+ *
+ * Options can be specified in the `gatling run` command by passing arguments with the format `key=value`, e.g.
+ * `gatling run option1=foo option2=bar`.
+ *
+ * @param key - the key of the option.
+ * @param defaultValue - a default value
+ * @returns the string value of the option if it is defined, or else `defaultValue` if provided, or else `undefined`.
+ */
+export const getOption: GetWithDefault = (key: string, defaultValue?: string) =>
+  getOrElse(JvmSystem.getProperty(key), defaultValue) as any;
+
+/**
+ * Gets the environment variable indicated by the specified name.
+ *
+ * @param name - the name of the environment variable.
+ * @param defaultValue - a default value
+ * @returns the string value of the environment variable if it is defined, or else `defaultValue` if provided, or else `undefined`.
+ */
+export const getEnvironmentVariable: GetWithDefault = (name: string, defaultValue?: string) =>
+  getOrElse(JvmSystem.getenv(name), defaultValue) as any;
+
+const getOrElse = (value: string | null, defaultValue?: string): string | undefined =>
+  typeof value === "string" ? value : defaultValue;

--- a/js/jvm-types/gatling.d.ts
+++ b/js/jvm-types/gatling.d.ts
@@ -3658,6 +3658,12 @@ declare namespace java.lang {
   } // end String
 } // end namespace java.lang
 declare namespace java.lang {
+  class System /* extends Object*/ {
+    equals(arg0: any /*java.lang.Object*/): boolean;
+    toString(): string;
+  } // end System
+} // end namespace java.lang
+declare namespace java.lang {
   interface Comparable<T> {
     compareTo(arg0: T): int;
   } // end Comparable
@@ -3887,6 +3893,7 @@ declare namespace java.util.stream {
     flatMapToLong(arg0: Func<T, any /*java.util.stream.LongStream*/>): any /*java.util.stream.LongStream*/;
     forEach(arg0: Consumer<T>): void;
     forEachOrdered(arg0: Consumer<T>): void;
+    gather<R>(arg0: any /*java.util.stream.Gatherer*/): Stream<R>;
     isParallel(): boolean;
     iterator(): java.util.Iterator<T>;
     limit(arg0: long): Stream<T>;

--- a/js/jvm-types/index.ts
+++ b/js/jvm-types/index.ts
@@ -2137,6 +2137,40 @@ interface StructureBuilderStatic {
 
 export const StructureBuilder: StructureBuilderStatic = Java.type("io.gatling.javaapi.core.StructureBuilder");
 
+interface SystemStatic {
+  readonly class: any;
+  console(): any /*java.io.Console*/;
+  getSecurityManager(): any /*java.lang.SecurityManager*/;
+  clearProperty(arg0: string): string;
+  getProperty(arg0: string): string;
+  getProperty(arg0: string, arg1: string): string;
+  getenv(arg0: string): string;
+  lineSeparator(): string;
+  setProperty(arg0: string, arg1: string): string;
+  getLogger(arg0: string): any /*java.lang.System$Logger*/;
+  getLogger(arg0: string, arg1: any /*java.util.ResourceBundle*/): any /*java.lang.System$Logger*/;
+  inheritedChannel(): any /*java.nio.channels.Channel*/;
+  getenv(): java.util.Map<string, string>;
+  getProperties(): any /*java.util.Properties*/;
+  identityHashCode(arg0: any /*java.lang.Object*/): int;
+  mapLibraryName(arg0: string): string;
+  currentTimeMillis(): long;
+  nanoTime(): long;
+  arraycopy(arg0: any /*java.lang.Object*/, arg1: int, arg2: any /*java.lang.Object*/, arg3: int, arg4: int): void;
+  exit(arg0: int): void;
+  gc(): void;
+  load(arg0: string): void;
+  loadLibrary(arg0: string): void;
+  runFinalization(): void;
+  setErr(arg0: any /*java.io.PrintStream*/): void;
+  setIn(arg0: any /*java.io.InputStream*/): void;
+  setOut(arg0: any /*java.io.PrintStream*/): void;
+  setProperties(arg0: any /*java.util.Properties*/): void;
+  setSecurityManager(arg0: any /*java.lang.SecurityManager*/): void;
+}
+
+export const System: SystemStatic = Java.type("java.lang.System");
+
 interface TemporalUnitStatic {
   readonly class: any;
 }

--- a/jvm/java2ts/src/main/java/io/gatling/javaapi/package-info.java
+++ b/jvm/java2ts/src/main/java/io/gatling/javaapi/package-info.java
@@ -17,6 +17,7 @@
 @Java2TS(
     declare = {
         // ********** java **********
+        @Type(value = java.lang.System.class, export = true),
         // java.time
         @Type(value = java.time.Duration.class, export = true),
         @Type(value = java.time.temporal.ChronoUnit.class, export = true),


### PR DESCRIPTION
## How it works:

- Users can access both environment variables and Java system properties
- Java sys props get exposed under a more "generic" name, since the Java sys props mechanism is just an implementation detail hidden from users (currently I named them "properties", to be discussed).
- Running locally with the CLI, we add an option for users to provide "properties"
- Running on Gatling Enterprise, the mechanism for providing both env vars and "properties" doesn't have to change, but the UI will need to rename the Java sys props for JS simulations.

## Example:

Note: using spaces in the "properties" keys in the example simply to show that it works, not that it's a good idea... Right now this only doesn't support using `=` in the key (because the CLI uses the `key=value` syntax).

In the code:

```typescript
import { getProperty, getEnvironmentVariable } from "@gatling.io/core";

const a = getProperty("My first property");
const b = getProperty("My second property", "default value");
const c = getEnvironmentVariable("ENV_VAR_1");
const d = getEnvironmentVariable("ENV_VAR_2", "default value");
```

Providing values through the CLI:

```shell
npx gatling run --simulation my-simulation --property "My first property=foo" "My second property=bar"
```

## Naming

- @slandelle suggests "parameter" instead of "property". My only concern is that, in Gatling Enterprise, we use "parameter" as a catch-all term for both system properties and environment variables?
- If we switch to positional parameters in the CLI (se below), "arg" or "argument" might make more sense?
- Other ideas?

## Named option vs. positional arguments

We could just add the `key=value` pairs as positional args to the `run` command:

```shell
npx gatling run --simulation my-simulation "My first property=foo" "My second property=bar"
```

Thinking about it, I think I prefer this solution (+ renaming "property" to "argument" ?).