### PR TITLE
chore: Update GraalVM to 22.0.2

### DIFF
--- a/js-simulation/package-lock.json
+++ b/js-simulation/package-lock.json
@@ -37,10 +37,10 @@
       "devDependencies": {
         "@types/archiver": "6.0.2",
         "@types/decompress": "4.2.7",
-        "@types/node": "20.14.9",
+        "@types/node": "20.14.12",
         "@types/readline-sync": "1.4.8",
-        "prettier": "3.3.2",
-        "rimraf": "5.0.7",
+        "prettier": "3.3.3",
+        "rimraf": "6.0.1",
         "typescript": "5.5.3"
       }
     },
@@ -1192,9 +1192,9 @@
       "devDependencies": {
         "@types/jest": "29.5.12",
         "jest": "29.7.0",
-        "prettier": "3.3.2",
-        "rimraf": "5.0.7",
-        "ts-jest": "29.1.5",
+        "prettier": "3.3.3",
+        "rimraf": "6.0.1",
+        "ts-jest": "29.2.3",
         "ts-node": "10.9.2",
         "typescript": "5.5.3"
       }
@@ -4990,9 +4990,9 @@
       "devDependencies": {
         "@types/jest": "29.5.12",
         "jest": "29.7.0",
-        "prettier": "3.3.2",
-        "rimraf": "5.0.7",
-        "ts-jest": "29.1.5",
+        "prettier": "3.3.3",
+        "rimraf": "6.0.1",
+        "ts-jest": "29.2.3",
         "ts-node": "10.9.2",
         "typescript": "5.5.3"
       }

--- a/jvm/build.sbt
+++ b/jvm/build.sbt
@@ -13,8 +13,8 @@ Global / gatlingDevelopers := Seq(
   GatlingDeveloper("ggaly@gatling.io", "Guillaume Galy", isGatlingCorp = true)
 )
 
-val graalvmJdkVersion = "22.0.1"
-val graalvmJsVersion = "24.0.1"
+val graalvmJdkVersion = "22.0.2"
+val graalvmJsVersion = "24.0.2"
 val coursierVersion = "2.1.10"
 val gatlingVersion = "3.11.5"
 

--- a/ts-simulation/package-lock.json
+++ b/ts-simulation/package-lock.json
@@ -38,10 +38,10 @@
       "devDependencies": {
         "@types/archiver": "6.0.2",
         "@types/decompress": "4.2.7",
-        "@types/node": "20.14.9",
+        "@types/node": "20.14.12",
         "@types/readline-sync": "1.4.8",
-        "prettier": "3.3.2",
-        "rimraf": "5.0.7",
+        "prettier": "3.3.3",
+        "rimraf": "6.0.1",
         "typescript": "5.5.3"
       }
     },
@@ -1193,9 +1193,9 @@
       "devDependencies": {
         "@types/jest": "29.5.12",
         "jest": "29.7.0",
-        "prettier": "3.3.2",
-        "rimraf": "5.0.7",
-        "ts-jest": "29.1.5",
+        "prettier": "3.3.3",
+        "rimraf": "6.0.1",
+        "ts-jest": "29.2.3",
         "ts-node": "10.9.2",
         "typescript": "5.5.3"
       }
@@ -4991,9 +4991,9 @@
       "devDependencies": {
         "@types/jest": "29.5.12",
         "jest": "29.7.0",
-        "prettier": "3.3.2",
-        "rimraf": "5.0.7",
-        "ts-jest": "29.1.5",
+        "prettier": "3.3.3",
+        "rimraf": "6.0.1",
+        "ts-jest": "29.2.3",
         "ts-node": "10.9.2",
         "typescript": "5.5.3"
       }


### PR DESCRIPTION
- GraalVM JDK : 22.0.2
- GraalJS : 24.0.2