### PR TITLE
feat: Rename run options to parameters

### DIFF
--- a/js/cli/src/index.ts
+++ b/js/cli/src/index.ts
@@ -133,23 +133,23 @@ const nonInteractiveOption = new Option(
   "Switch to non-interactive mode and fail if no simulation is explicitly specified"
 ).default(false);
 
-const runOptionsArgument = new Argument(
+const runParametersArgument = new Argument(
   "[optionKey=optionValue...]",
-  "Specify one or more option which can be read in the simulation script with the getOption() function; format must be key=value"
+  "Specify one or more parameter which can be read in the simulation script with the getParameter() function; format must be key=value"
 );
 
-const parseRunOptions = (args: string[]): Record<string, string> => {
-  const parsedOptions: Record<string, string> = {};
+const parseRunParameters = (args: string[]): Record<string, string> => {
+  const parsedParameters: Record<string, string> = {};
   for (const arg of args) {
     const i = arg.indexOf("=");
     if (i < 0) {
-      throw Error(`Option '${arg}' is not valid: format should be key=value`);
+      throw Error(`Parameter '${arg}' is not valid: format should be key=value`);
     } else {
       const key = arg.slice(0, i).trim();
-      parsedOptions[key] = arg.slice(i + 1);
+      parsedParameters[key] = arg.slice(i + 1);
     }
   }
-  return parsedOptions;
+  return parsedParameters;
 };
 
 program
@@ -190,7 +190,7 @@ program
   .addOption(resourcesFolderOption)
   .addOption(resultsFolderOption)
   .addOption(memoryOption)
-  .addArgument(runOptionsArgument)
+  .addArgument(runParametersArgument)
   .action(async (args: string[], options) => {
     const graalvmHome: string = options.graalvmHome;
     const jvmClasspath: string = options.jvmClasspath;
@@ -199,7 +199,7 @@ program
     const resourcesFolder: string = options.resourcesFolder;
     const resultsFolder: string = options.resultsFolder;
     const memory: number | undefined = options.memory;
-    const runOptions = parseRunOptions(args);
+    const runParameters = parseRunParameters(args);
 
     await runSimulation({
       graalvmHome,
@@ -209,7 +209,7 @@ program
       resourcesFolder,
       resultsFolder,
       memory,
-      runOptions
+      runParameters
     });
   });
 
@@ -227,7 +227,7 @@ program
   .addOption(gatlingHomeOption)
   .addOption(memoryOption)
   .addOption(nonInteractiveOption)
-  .addArgument(runOptionsArgument)
+  .addArgument(runParametersArgument)
   .action(async (args: string[], options) => {
     const gatlingHome = gatlingHomeDirWithDefaults(options);
     const sourcesFolder: string = options.sourcesFolder;
@@ -236,7 +236,7 @@ program
     const resultsFolder: string = options.resultsFolder;
     const memory: number | undefined = options.memory;
     const nonInteractive: boolean = options.nonInteractive;
-    const runOptions = parseRunOptions(args);
+    const runParameters = parseRunParameters(args);
 
     const simulations = await findSimulations(sourcesFolder);
     const typescript = typescriptWithDefaults(options, simulations);
@@ -257,7 +257,7 @@ program
       resourcesFolder,
       resultsFolder,
       memory,
-      runOptions
+      runParameters
     });
   });
 

--- a/js/cli/src/run.ts
+++ b/js/cli/src/run.ts
@@ -8,7 +8,7 @@ export interface RunSimulationOptions extends RunJavaProcessOptions {
   resourcesFolder: string;
   resultsFolder: string;
   memory?: number;
-  runOptions: Record<string, string>;
+  runParameters: Record<string, string>;
 }
 
 export interface RunRecorderOptions extends RunJavaProcessOptions {
@@ -27,7 +27,7 @@ export const runSimulation = async (options: RunSimulationOptions): Promise<void
   const additionalClasspathElements = [options.resourcesFolder];
   const memoryArgs = options.memory !== undefined ? [`-Xms${options.memory}M`, `-Xmx${options.memory}M`] : [];
   const javaArgs = [
-    ...Object.entries(options.runOptions).map(([key, value]) => `-D${key}=${value}`),
+    ...Object.entries(options.runParameters).map(([key, value]) => `-D${key}=${value}`),
     `-Dgatling.js.bundle.filePath=${options.bundleFile}`,
     `-Dgatling.js.simulation=${options.simulation}`,
     ...memoryArgs

--- a/js/core/src/index.ts
+++ b/js/core/src/index.ts
@@ -23,7 +23,7 @@ export * from "./filters";
 export { GlobalStore } from "./globalStore";
 export * from "./openInjection";
 export * from "./population";
-export { getOption, getEnvironmentVariable, GetWithDefault } from "./parameters";
+export { getParameter, getOption, getEnvironmentVariable, GetWithDefault } from "./parameters";
 export * from "./protocol";
 export * from "./scenario";
 export * from "./session";

--- a/js/core/src/parameters.ts
+++ b/js/core/src/parameters.ts
@@ -6,17 +6,23 @@ export interface GetWithDefault {
 }
 
 /**
- * Gets the option indicated by the specified name.
+ * Gets the parameter indicated by the specified name.
  *
- * Options can be specified in the `gatling run` command by passing arguments with the format `key=value`, e.g.
- * `gatling run option1=foo option2=bar`.
+ * Parameters can be specified in the `gatling run` command by passing arguments with the format `key=value`, e.g.
+ * `gatling run parameter1=foo parameter2=bar`. You would then retrieve them in your simulation by calling
+ * `getParameter("parameter1")` and `getParameter("parameter2")`.
  *
- * @param key - the key of the option.
+ * @param key - the key of the parameter.
  * @param defaultValue - a default value
- * @returns the string value of the option if it is defined, or else `defaultValue` if provided, or else `undefined`.
+ * @returns the string value of the parameter if it is defined, or else `defaultValue` if provided, or else `undefined`.
  */
-export const getOption: GetWithDefault = (key: string, defaultValue?: string) =>
+export const getParameter: GetWithDefault = (key: string, defaultValue?: string) =>
   getOrElse(JvmSystem.getProperty(key), defaultValue) as any;
+
+/**
+ * @deprecated Use {@link getParameter} instead.
+ */
+export const getOption: GetWithDefault = getParameter;
 
 /**
  * Gets the environment variable indicated by the specified name.


### PR DESCRIPTION
User-visible changes:
- In the DSL, deprecation of `getOption`, replaced by `getParameter`.
- On the CLI, only the wording used in the help text changes.