### PR TITLE
chore: Use a Node.js typings version consistent with the documentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       day: "sunday"
     ignore:
       - dependency-name: "@gatling.io/*"
+      # the major version for Node should match the minimum version required in the documentation
+      - dependency-name: "@types/node"
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: "npm"
     directory: "/js-simulation"
     labels:

--- a/js-simulation/package-lock.json
+++ b/js-simulation/package-lock.json
@@ -37,7 +37,7 @@
       "devDependencies": {
         "@types/archiver": "6.0.2",
         "@types/decompress": "4.2.7",
-        "@types/node": "20.14.12",
+        "@types/node": "18.19.49",
         "@types/readline-sync": "1.4.8",
         "prettier": "3.3.3",
         "rimraf": "6.0.1",

--- a/js/cli/package.json
+++ b/js/cli/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/archiver": "6.0.2",
     "@types/decompress": "4.2.7",
-    "@types/node": "20.14.12",
+    "@types/node": "18.19.49",
     "@types/readline-sync": "1.4.8",
     "prettier": "3.3.3",
     "rimraf": "6.0.1",

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -36,11 +36,20 @@
       "devDependencies": {
         "@types/archiver": "6.0.2",
         "@types/decompress": "4.2.7",
-        "@types/node": "20.14.12",
+        "@types/node": "18.19.49",
         "@types/readline-sync": "1.4.8",
         "prettier": "3.3.3",
         "rimraf": "6.0.1",
         "typescript": "5.5.4"
+      }
+    },
+    "cli/node_modules/@types/node": {
+      "version": "18.19.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.49.tgz",
+      "integrity": "sha512-ALCeIR6n0nQ7j0FUF1ycOhrp6+XutJWqEu/vtdEqXFUQwkBfgUA5cEg3ZNmjWGF/ZYA/FcF9QMkL55Ar0O6UrA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "core": {

--- a/ts-simulation/package-lock.json
+++ b/ts-simulation/package-lock.json
@@ -38,7 +38,7 @@
       "devDependencies": {
         "@types/archiver": "6.0.2",
         "@types/decompress": "4.2.7",
-        "@types/node": "20.14.12",
+        "@types/node": "18.19.49",
         "@types/readline-sync": "1.4.8",
         "prettier": "3.3.3",
         "rimraf": "6.0.1",


### PR DESCRIPTION
Use Node typings corresponding to the minimum version we require in the documentation (currently Node 18), so that we don't accidentally use newer features.

See https://docs.gatling.io/tutorials/scripting-intro-js/#install-gatling