### PR TITLE
fix: Show correct simulation name in reports (local runs)

### DIFF
--- a/js/cli/src/run.ts
+++ b/js/cli/src/run.ts
@@ -40,6 +40,8 @@ export const runSimulation = async (options: RunSimulationOptions): Promise<void
     options.resultsFolder,
     "--simulation",
     "io.gatling.js.JsSimulation",
+    "--simulation-name",
+    options.simulation,
     "--launcher",
     "gatling-js-cli",
     "--build-tool-version",

--- a/jvm/build.sbt
+++ b/jvm/build.sbt
@@ -17,7 +17,7 @@ val compilerRelease = 21
 val graalvmJdkVersion = "23.0.0"
 val graalvmJsVersion = "24.1.1"
 val coursierVersion = "2.1.12"
-val gatlingVersion = "3.13.1"
+val gatlingVersion = "3.13.2-SNAPSHOT"
 
 // bit weird cause this is not a dependency of this project
 val gatlingEnterpriseComponentPluginVersion = "1.9.8"


### PR DESCRIPTION
Draft - depends on gatling/gatling-private#1033

-----

Motivation:

Local run reports currently show the name of the Java adapter class instead of the simulation name.

Modifications:

Override simulation name with the correct name.

Result:

Reports show the expected simulation name (derived from the simulation file name).