### PR TITLE
feat: Add trust store configuration to the CLI

### DIFF
--- a/js-simulation/package-lock.json
+++ b/js-simulation/package-lock.json
@@ -27,7 +27,7 @@
         "archiver": "7.0.1",
         "commander": "13.1.0",
         "esbuild": "0.25.0",
-        "esbuild-plugin-tsc": "0.4.0",
+        "esbuild-plugin-tsc": "0.5.0",
         "import-meta-resolve": "4.1.0",
         "make-fetch-happen": "14.0.3",
         "node-stream-zip": "1.15.0",
@@ -39,11 +39,11 @@
       "devDependencies": {
         "@types/archiver": "6.0.3",
         "@types/make-fetch-happen": "10.0.4",
-        "@types/node": "18.19.76",
+        "@types/node": "18.19.78",
         "@types/readline-sync": "1.4.8",
-        "prettier": "3.5.2",
+        "prettier": "3.5.3",
         "rimraf": "6.0.1",
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
       }
     },
     "../tmp/cli/package/node_modules/@esbuild/darwin-arm64": {
@@ -1916,11 +1916,11 @@
       "devDependencies": {
         "@types/jest": "29.5.14",
         "jest": "29.7.0",
-        "prettier": "3.5.2",
+        "prettier": "3.5.3",
         "rimraf": "6.0.1",
         "ts-jest": "29.2.6",
         "ts-node": "10.9.2",
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
       }
     },
     "../tmp/core/package/node_modules/@ampproject/remapping": {
@@ -5615,11 +5615,11 @@
       "devDependencies": {
         "@types/jest": "29.5.14",
         "jest": "29.7.0",
-        "prettier": "3.5.2",
+        "prettier": "3.5.3",
         "rimraf": "6.0.1",
         "ts-jest": "29.2.6",
         "ts-node": "10.9.2",
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
       }
     },
     "../tmp/http/package/node_modules/@ampproject/remapping": {
@@ -9312,7 +9312,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
       }
     },
     "../tmp/jvm-types/package/node_modules/typescript": {

--- a/js/cli/src/commands/enterpriseDeploy.ts
+++ b/js/cli/src/commands/enterpriseDeploy.ts
@@ -23,6 +23,10 @@ import {
   resultsFolderOptionValue,
   sourcesFolderOption,
   sourcesFolderOptionValue,
+  trustStoreOption,
+  trustStoreOptionValue,
+  trustStorePasswordOption,
+  trustStorePasswordOptionValue,
   typescriptOption,
   typescriptOptionValueWithDefaults,
   apiUrlOption,
@@ -52,6 +56,8 @@ export default (program: Command): void => {
     .addOption(apiTokenOption)
     // Plugin configuration
     .addOption(controlPlaneUrlOption)
+    .addOption(trustStoreOption)
+    .addOption(trustStorePasswordOption)
     .addOption(nonInteractiveOption)
     // Descriptor file
     .addOption(packageDescriptorFilenameOption)
@@ -72,6 +78,8 @@ export default (program: Command): void => {
       const webAppUrl = webAppUrlOptionValue(options);
       const apiToken = apiTokenOptionValue(options);
       const controlPlaneUrl = controlPlaneUrlOptionValue(options);
+      const trustStore = trustStoreOptionValue(options);
+      const trustStorePassword = trustStorePasswordOptionValue(options);
       const nonInteractive = nonInteractiveOptionValue(options);
       const packageDescriptorFilename = packageDescriptorFilenameOptionValue(options);
       const packageFile = packageFileOptionValue(options);
@@ -89,6 +97,8 @@ export default (program: Command): void => {
         webAppUrl,
         apiToken,
         controlPlaneUrl,
+        trustStore,
+        trustStorePassword,
         nonInteractive,
         packageDescriptorFilename,
         packageFile

--- a/js/cli/src/commands/enterpriseStart.ts
+++ b/js/cli/src/commands/enterpriseStart.ts
@@ -29,6 +29,10 @@ import {
   runTitleOptionValue,
   sourcesFolderOption,
   sourcesFolderOptionValue,
+  trustStoreOption,
+  trustStoreOptionValue,
+  trustStorePasswordOption,
+  trustStorePasswordOptionValue,
   typescriptOption,
   typescriptOptionValueWithDefaults,
   apiUrlOption,
@@ -60,6 +64,8 @@ export default (program: Command): void => {
     .addOption(apiTokenOption)
     // Plugin configuration
     .addOption(controlPlaneUrlOption)
+    .addOption(trustStoreOption)
+    .addOption(trustStorePasswordOption)
     .addOption(nonInteractiveOption)
     // Descriptor file
     .addOption(packageDescriptorFilenameOption)
@@ -85,6 +91,8 @@ export default (program: Command): void => {
       const webAppUrl = webAppUrlOptionValue(options);
       const apiToken = apiTokenOptionValue(options);
       const controlPlaneUrl = controlPlaneUrlOptionValue(options);
+      const trustStore = trustStoreOptionValue(options);
+      const trustStorePassword = trustStorePasswordOptionValue(options);
       const nonInteractive = nonInteractiveOptionValue(options);
       const packageDescriptorFilename = packageDescriptorFilenameOptionValue(options);
       const packageFile = packageFileOptionValue(options);
@@ -110,6 +118,8 @@ export default (program: Command): void => {
         webAppUrl,
         apiToken,
         controlPlaneUrl,
+        trustStore,
+        trustStorePassword,
         nonInteractive,
         packageDescriptorFilename,
         packageFile,

--- a/js/cli/src/commands/options.ts
+++ b/js/cli/src/commands/options.ts
@@ -282,6 +282,18 @@ export const controlPlaneUrlOption = new Option(
 );
 export const controlPlaneUrlOptionValue = getStringValueOptional(controlPlaneUrlOption);
 
+export const trustStoreOption = new Option(
+  "--trust-store <value>",
+  `Path to a trust store (in PKCS#12 or JKS format) used when calling remote APIs over HTTPS. Useful with the ${controlPlaneUrlOption.long} option, if your control plane uses a certificate signed by an internal CA.`
+);
+export const trustStoreOptionValue = getStringValueOptional(trustStoreOption);
+
+export const trustStorePasswordOption = new Option(
+  "--trust-store-password <value>",
+  `Use with the ${trustStoreOption.long} option, if your trust store is protected by a password.`
+);
+export const trustStorePasswordOptionValue = getStringValueOptional(trustStorePasswordOption);
+
 // Descriptor file
 
 export const packageDescriptorFilenameOption = new Option(

--- a/js/cli/src/enterprise.ts
+++ b/js/cli/src/enterprise.ts
@@ -134,6 +134,8 @@ export interface EnterprisePluginOptions extends RunJavaProcessOptions {
   apiToken?: string;
   // Plugin configuration
   controlPlaneUrl?: string;
+  trustStore?: string;
+  trustStorePassword?: string;
   nonInteractive: boolean;
 }
 
@@ -150,6 +152,12 @@ const javaArgsFromPluginOptions = (options: EnterprisePluginOptions) => {
   // Plugin configuration
   if (options.controlPlaneUrl !== undefined) {
     javaArgs.push(`-Dgatling.enterprise.controlPlaneUrl=${options.controlPlaneUrl}`);
+  }
+  if (options.trustStore !== undefined) {
+    javaArgs.push(`-Djavax.net.ssl.trustStore=${options.trustStore}`);
+  }
+  if (options.trustStore !== undefined && options.trustStorePassword !== undefined) {
+    javaArgs.push(`-Djavax.net.ssl.trustStorePassword=${options.trustStorePassword}`);
   }
   javaArgs.push("-Dgatling.enterprise.buildTool=js-cli");
   javaArgs.push(`-Dgatling.enterprise.pluginVersion=${versions.gatling.jsAdapter}`);

--- a/ts-simulation/package-lock.json
+++ b/ts-simulation/package-lock.json
@@ -28,7 +28,7 @@
         "archiver": "7.0.1",
         "commander": "13.1.0",
         "esbuild": "0.25.0",
-        "esbuild-plugin-tsc": "0.4.0",
+        "esbuild-plugin-tsc": "0.5.0",
         "import-meta-resolve": "4.1.0",
         "make-fetch-happen": "14.0.3",
         "node-stream-zip": "1.15.0",
@@ -40,11 +40,11 @@
       "devDependencies": {
         "@types/archiver": "6.0.3",
         "@types/make-fetch-happen": "10.0.4",
-        "@types/node": "18.19.76",
+        "@types/node": "18.19.78",
         "@types/readline-sync": "1.4.8",
-        "prettier": "3.5.2",
+        "prettier": "3.5.3",
         "rimraf": "6.0.1",
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
       }
     },
     "../tmp/cli/package/node_modules/@esbuild/darwin-arm64": {
@@ -1917,11 +1917,11 @@
       "devDependencies": {
         "@types/jest": "29.5.14",
         "jest": "29.7.0",
-        "prettier": "3.5.2",
+        "prettier": "3.5.3",
         "rimraf": "6.0.1",
         "ts-jest": "29.2.6",
         "ts-node": "10.9.2",
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
       }
     },
     "../tmp/core/package/node_modules/@ampproject/remapping": {
@@ -5616,11 +5616,11 @@
       "devDependencies": {
         "@types/jest": "29.5.14",
         "jest": "29.7.0",
-        "prettier": "3.5.2",
+        "prettier": "3.5.3",
         "rimraf": "6.0.1",
         "ts-jest": "29.2.6",
         "ts-node": "10.9.2",
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
       }
     },
     "../tmp/http/package/node_modules/@ampproject/remapping": {
@@ -9313,7 +9313,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
       }
     },
     "../tmp/jvm-types/package/node_modules/typescript": {


### PR DESCRIPTION
Being able to configure a custom trust store is useful with private packages, as the control plane may use a certificate from an internal CA.