### PR TITLE
fix: add cases to handle file system resolution differently in Windows

### DIFF
--- a/jvm/adapter/src/main/java/io/gatling/js/JsSimulationHelper.java
+++ b/jvm/adapter/src/main/java/io/gatling/js/JsSimulationHelper.java
@@ -18,7 +18,9 @@ package io.gatling.js;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -78,7 +80,8 @@ public class JsSimulationHelper {
 
   private static URL filePathToUrl(String filePath) {
     try {
-      return Paths.get(filePath).toUri().toURL();
+      Path path = Paths.get(filePath);
+      return URI.create("file:" + path.toString().replaceAll("\\\\", "/")).toURL();
     } catch (MalformedURLException e) {
       throw new IllegalArgumentException("Not a valid file path: " + filePath, e);
     }


### PR DESCRIPTION
In Windows, Paths.get(path).toUri().toUrl() can get prefixed with a slash if the path is absolute, just so can differentiate between absolute and relative paths, e.g.: /C:/Devel/...

Short explanation: this breaks everything else