### PR TITLE
chore: Update GraalVM to JDK 25.0.0

### DIFF
--- a/jvm/build.sbt
+++ b/jvm/build.sbt
@@ -14,7 +14,7 @@ Global / gatlingDevelopers := Seq(
 )
 
 val compilerRelease = 21
-val graalvmJdkVersion = "24.0.2"
+val graalvmJdkVersion = "25.0.0"
 val graalvmJsVersion = "25.0.0"
 val gatlingVersion = "3.14.4"
 


### PR DESCRIPTION
Upgrade the GraalVM version included in the dependency bundle.