### PR TITLE
chore: update gatling-enterprise-plugin-commons to 1.20.3, closes RNG…

### DIFF
--- a/jvm/build.sbt
+++ b/jvm/build.sbt
@@ -21,7 +21,7 @@ val gatlingVersion = "3.14.5"
 val gatlingMqttVersion = "3.14.5"
 
 // bit weird cause this is not a dependency of this project
-val gatlingEnterpriseComponentPluginVersion = "1.20.2"
+val gatlingEnterpriseComponentPluginVersion = "1.20.3"
 
 lazy val root = (project in file("."))
   .aggregate(adapter, java2ts)


### PR DESCRIPTION
…-119

Motivation:
New dedicated endpoint is used in new enterprise common plugin version.

Modifications:
Update gatling-enterprise-plugin-commons version

Result:
Updated gatling-js dependency.