### PR TITLE
fix: support proto files organised in subdirectories for gRPC dynamic…

### DIFF
--- a/js/cli/src/bundle/protoc.ts
+++ b/js/cli/src/bundle/protoc.ts
@@ -14,11 +14,10 @@ export const compileProtoFiles = async (
   const allGeneratedFiles: string[] = [];
   for (const protoFile of protoFiles) {
     const sourceFile = path.join(protoFolder, protoFile);
-    const protoPath = path.dirname(sourceFile);
     const targetFile = protoFile + "c";
     const targetPath = path.join(protoTargetFolder, targetFile);
     await fs.mkdir(path.dirname(targetPath), { recursive: true });
-    await runProtoc(protocPath, sourceFile, protoPath, targetPath);
+    await runProtoc(protocPath, sourceFile, protoFolder, targetPath);
     allGeneratedFiles.push(targetFile);
   }
   if (protoFiles.length > 0) {

--- a/jvm/adapter/src/main/java/io/gatling/javaapi/grpc/GrpcDynamic.java
+++ b/jvm/adapter/src/main/java/io/gatling/javaapi/grpc/GrpcDynamic.java
@@ -257,21 +257,17 @@ public class GrpcDynamic {
                     e);
               }
 
-              final var parent = Paths.get(resource).getParent();
               return fileDescriptorSet.getFileList().stream()
                   .map(
                       fileDescriptorProto -> {
-                        final var path =
-                            parent != null
-                                ? parent.resolve(fileDescriptorProto.getName())
-                                : Paths.get(fileDescriptorProto.getName());
+                        final var path = Paths.get(fileDescriptorProto.getName());
                         return new Pair<>(path, fileDescriptorProto);
                       });
             })
         .collect(Collectors.toMap(p -> p.key, p -> p.value));
   }
 
-  /** Uses relative paths to proto file dependencies. */
+  /** Uses proto-path-root-relative paths for file descriptor names and their dependencies. */
   private static Descriptors.FileDescriptor resolveFileDescriptor(
       Path protoPath,
       Map<Path, DescriptorProtos.FileDescriptorProto> fileDescriptorProtos,
@@ -291,9 +287,7 @@ public class GrpcDynamic {
               proto.getDependencyList().stream()
                   .map(
                       dependency -> {
-                        final var parent = protoPath.getParent();
-                        final var dependencyPath =
-                            parent != null ? parent.resolve(dependency) : Paths.get(dependency);
+                        final var dependencyPath = Paths.get(dependency);
                         try {
                           return resolveFileDescriptor(dependencyPath, fileDescriptorProtos, cache);
                         } catch (Descriptors.DescriptorValidationException e) {


### PR DESCRIPTION
Motivation:

When proto files are placed in subdirectories (e.g. protobuf/greeting/greeting.proto), protoc was invoked with --proto_path set to each file's own directory, so descriptor names in the generated .protoc files were bare filenames (e.g. greeting.proto). GrpcDynamic.loadFileDescriptors then prepended the .protoc file's parent path to those names to build map keys (e.g. greeting/greeting.proto), and resolveFileDescriptor did the same for each dependency — which happened to work for flat layouts but broke as soon as files moved into subdirectories, producing doubly-prefixed paths like greeting/greeting/greeting.proto or greeting/greeting/greeting/greeting_messages.proto.

Modification:

- protoc.ts: pass protoFolder (the root proto directory) as --proto_path for every file instead of path.dirname(sourceFile). Descriptor names are now root-relative paths (e.g. greeting/greeting.proto), consistent with standard protobuf import conventions.
- GrpcDynamic.java: use Paths.get(fileDescriptorProto.getName()) directly as the map key in loadFileDescriptors (removing the parent.resolve() call), and likewise use Paths.get(dependency) directly in resolveFileDescriptor (removing the second parent.resolve() call). Both values are already root-relative and need no further prefixing.

Result:

Proto files can now be organised in arbitrary subdirectories under the proto root. Build and dynamic descriptor resolution work correctly for both flat and nested layouts.