### PR TITLE
chore: add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       interval: "weekly"
       day: "monday" # explicit, even though it's the weekly default
       time: "07:00" # UTC
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directories:
       - "/js"
@@ -22,7 +24,9 @@ updates:
       - dependency-name: "@gatling.io/*"
       # the major version for Node should match the minimum version required in the documentation
       - dependency-name: "@types/node"
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directories:
       - "/js-simulation"
@@ -37,3 +41,5 @@ updates:
       interval: "weekly"
       day: "monday" # explicit, even though it's the weekly default
       time: "07:00" # UTC
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Delays Dependabot version updates by 7 days after a new release is
published. This reduces exposure to supply-chain attacks (malicious
or compromised packages are typically caught and pulled within days
of publication) and supports SOC 2 change-management controls around
vetted, non-immediate dependency updates.

Adds a `cooldown: default-days: 7` block to each `updates` entry in
`.github/dependabot.yml`. See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/reducing-the-number-of-pull-requests-dependabot-opens#configuring-cooldown-options
